### PR TITLE
Enable passing in custom args when starting one-app engine

### DIFF
--- a/bin/rnx
+++ b/bin/rnx
@@ -56,8 +56,11 @@ scriptPath=${rnxRoot}/scripts/$script.sh
 
 shift
 if [ -f $scriptPath ]; then
-
-    export USE_ENGINE=$(jq -r '.rnx.useOneAppEngine' package.json)
+    ENGINE_CFG=$(jq -r '.rnx.useOneAppEngine' package.json)
+    if [ "${ENGINE_CFG}" != "null" ]; then
+        export USE_ENGINE="true"
+        export ENGINE_START_ARGS=$(jq -r '.rnx.useOneAppEngine.withStartArgs' package.json)
+    fi
     sh $scriptPath $@
 else
     echo "==================================================="

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -14,12 +14,16 @@ adb reverse tcp:8081 tcp:8081 >/dev/null 2>&1
 adb reverse tcp:3000 tcp:3000 >/dev/null 2>&1
 
 if [[ "${USE_ENGINE}" == true ]]; then
-  mockMode="offline"
-  if [[ $* == *--prod* ]]; then 
+  if [[ $* == *--prod* ]]; then
     mockMode="quickLogin"
+  else
+    mockMode="offline"
+    engineArgs="${ENGINE_START_ARGS}"
   fi
 
-  one-app-engine --mock-mode $mockMode
+  set -x
+  one-app-engine --mock-mode $mockMode $engineArgs
+  set +x
 else 
   node node_modules/react-native/local-cli/cli.js start
 fi


### PR DESCRIPTION
This would enable things such as:
```
  "rnx": {
   ...
    "useOneAppEngine": {
      "withStartArgs": "--custom-extensions e2e.js"
    }
  },
```

instead of just:
```
  "rnx": {
    "useOneAppEngine": true
  },
```